### PR TITLE
Fixed an issue with the TagDistributor where a NullPointerException was thrown

### DIFF
--- a/src/main/java/bitflow4j/steps/fork/distribute/TagDistributor.java
+++ b/src/main/java/bitflow4j/steps/fork/distribute/TagDistributor.java
@@ -88,11 +88,13 @@ public class TagDistributor implements ScriptableDistributor {
             return tagValueCache.get(value);
         } else {
             List<Pair<String, Pipeline>> result = new ArrayList<>();
-            for (Pair<String, PipelineBuilder> available : subPipelineBuilders) {
-                if (matches(available.getLeft(), value)) {
-                    Pipeline pipeline = getPipeline(available.getLeft(), value, available.getRight());
-                    if (pipeline != null) {
-                        result.add(new Pair<>(value, pipeline));
+            if(subPipelineBuilders != null){
+                for (Pair<String, PipelineBuilder> available : subPipelineBuilders) {
+                    if (matches(available.getLeft(), value)) {
+                        Pipeline pipeline = getPipeline(available.getLeft(), value, available.getRight());
+                        if (pipeline != null) {
+                            result.add(new Pair<>(value, pipeline));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
…s thrown when the TagDistributor gets called without defining Sub-Pipelines before (just the constructor with a string). There will be a warning logged and the value of the tag will be skipped, as before.