### PR TITLE
Docker adjustment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN mvn clean install
 RUN cp /build-bitflow4j/target/bitflow4j-*-jar-with-dependencies.jar /build-bitflow4j/bitflow4j-with-dependencies.jar
 
-FROM java:11-jre-alpine
+FROM openjdk:11-jre-slim
 WORKDIR /
 COPY --from=build /build-bitflow4j/bitflow4j-with-dependencies.jar .
 ENTRYPOINT ["java", "-jar", "bitflow4j-with-dependencies.jar"]

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,5 +1,5 @@
 # teambitflow/bitflow4j-build
-# docker build -t teambitflow/bitflow4j-build .
+# docker build -t teambitflow/bitflow4j-build -f build.Dockerfile .
 FROM maven:3.6-jdk-11
 WORKDIR /build-bitflow4j
 COPY . .


### PR DESCRIPTION
The Java (java:) image is deprecated and openjdk should be used:
https://hub.docker.com/_/java 
There is no alpine image, just the slim version for now:
https://stackoverflow.com/questions/53375613/why-is-the-java-11-base-docker-image-so-large-openjdk11-jre-slim 

Adjusted this in the Dockerfile as the current image did not exist :)