### PR TITLE
If a relative file in the current directory was defined, a NPE was th…

### DIFF
--- a/src/main/java/bitflow4j/io/file/FileSink.java
+++ b/src/main/java/bitflow4j/io/file/FileSink.java
@@ -52,7 +52,7 @@ public class FileSink extends MarshallingSampleWriter {
         } while (!append && file.exists());
 
         //Create directory structure if it does not exist yet
-        File directory = new File(file.getParentFile().getAbsolutePath());
+        File directory = new File(file.getAbsoluteFile().getParentFile().getAbsolutePath());
         directory.mkdirs();
 
         if (!file.exists() && !file.createNewFile()) {


### PR DESCRIPTION
…rown when trying to access the parent. By accessing the absolute file first, this will not happen anymore.