### PR TITLE
Fix for OnlineWindowsStatistics

### DIFF
--- a/src/main/java/bitflow4j/misc/OnlineWindowStatistics.java
+++ b/src/main/java/bitflow4j/misc/OnlineWindowStatistics.java
@@ -21,7 +21,7 @@ public class OnlineWindowStatistics extends OnlineStatistics {
     public void push(double x) {
         if (window.isFull()) {
             double oldest = (double) window.get();
-            //remove(oldest);
+            remove(oldest);
             window.remove();
         }
         super.push(x);


### PR DESCRIPTION
Fixed that OnlineWindowsStatistics was ignoring the window size for mean calculation. 