### PR TITLE
Fixed InfluxDB connector

### DIFF
--- a/src/main/java/bitflow4j/script/endpoints/Endpoint.java
+++ b/src/main/java/bitflow4j/script/endpoints/Endpoint.java
@@ -59,7 +59,7 @@ public class Endpoint {
     }
 
     public enum Format {
-        UNDEFINED, TEXT, CSV, BINARY, WAV;
+        UNDEFINED, TEXT, CSV, BIN, WAV;
 
         public static Format find(String search) {
             for (Format t : Format.values()) {
@@ -72,7 +72,7 @@ public class Endpoint {
 
         public Marshaller getMarshaller() {
             switch (this) {
-                case BINARY:
+                case BIN:
                     return new BinaryMarshaller();
                 case CSV:
                     return new CsvMarshaller();

--- a/src/main/java/bitflow4j/script/endpoints/EndpointFactory.java
+++ b/src/main/java/bitflow4j/script/endpoints/EndpointFactory.java
@@ -160,10 +160,10 @@ public class EndpointFactory {
         switch (type) {
             case TCP:
             case LISTEN:
-                return Endpoint.Format.BINARY;
+                return Endpoint.Format.BIN;
             case FILE:
                 if (target.endsWith(".bin")) {
-                    return Endpoint.Format.BINARY;
+                    return Endpoint.Format.BIN;
                 } else if (target.endsWith(".wav")) {
                     return Endpoint.Format.WAV;
                 } else {

--- a/src/test/java/bitflow4j/script/endpoints/EndpointFactoryTest.java
+++ b/src/test/java/bitflow4j/script/endpoints/EndpointFactoryTest.java
@@ -52,7 +52,7 @@ public class EndpointFactoryTest {
 
     @Test
     public void givenTCPEndpoints_whenCreateSink_thenReturnTCPSink() throws IOException {
-        String fileEndpoint = "tcp+binary://0.1.2.3:8012";
+        String fileEndpoint = "tcp+bin://0.1.2.3:8012";
 
         PipelineStep sink = new EndpointFactory().createSink(fileEndpoint);
 
@@ -148,22 +148,22 @@ public class EndpointFactoryTest {
         // standard format for std is text
         executeTest("std://-", Endpoint.Type.STD, Endpoint.Format.CSV, "-");
         // standard format for tcp is bin
-        executeTest("tcp://" + sampleHostPort, Endpoint.Type.TCP, Endpoint.Format.BINARY, sampleHostPort);
+        executeTest("tcp://" + sampleHostPort, Endpoint.Type.TCP, Endpoint.Format.BIN, sampleHostPort);
         // standard format for file with .bin ending is binary
-        executeTest("file://filename.bin", Endpoint.Type.FILE, Endpoint.Format.BINARY, "filename.bin");
+        executeTest("file://filename.bin", Endpoint.Type.FILE, Endpoint.Format.BIN, "filename.bin");
         executeTest("file://filename.csv", Endpoint.Type.FILE, Endpoint.Format.CSV, "filename.csv");
         // standard format for other files is binary
         executeTest("file://filename", Endpoint.Type.FILE, Endpoint.Format.CSV, "filename");
 
         // GUESSES
         // guess host and port as tcp
-        executeTest(sampleHostPort, Endpoint.Type.TCP, Endpoint.Format.BINARY, sampleHostPort);
+        executeTest(sampleHostPort, Endpoint.Type.TCP, Endpoint.Format.BIN, sampleHostPort);
         // guess port as tcp listen
-        executeTest(":8000", Endpoint.Type.LISTEN, Endpoint.Format.BINARY, ":8000");
+        executeTest(":8000", Endpoint.Type.LISTEN, Endpoint.Format.BIN, ":8000");
         // guess file
         executeTest("/opt/somefile", Endpoint.Type.FILE, Endpoint.Format.CSV, "/opt/somefile");
         // guess CSV file
-        executeTest("/opt/somefile.bin", Endpoint.Type.FILE, Endpoint.Format.BINARY, "/opt/somefile.bin");  
+        executeTest("/opt/somefile.bin", Endpoint.Type.FILE, Endpoint.Format.BIN, "/opt/somefile.bin");
         // guess wav file
         executeTest("/opt/somefile.wav", Endpoint.Type.FILE, Endpoint.Format.WAV, "/opt/somefile.wav");
         // guess console


### PR DESCRIPTION
connecting when receiving first sample, not crashing on connection error, better error message, filtering bad values that cause crash, added option to limit number of metrics per point. Renamed bitflow marshalling type from BINARY to BIN to comply with other implementations.