### PR TITLE
Add Dockerfiles for arm32v7 and arm64v8 architectures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,8 +86,8 @@ pipeline {
             steps {
                 script {
                     dockerImage = docker.build registry + ':$BRANCH_NAME-build-$BUILD_NUMBER'
-                    dockerImageARM32 = docker.build registry + ':$BRANCH_NAME-build-$BUILD_NUMBER-arm32v7', '-f arm32v7.Dockerfile'
-                    dockerImageARM64 = docker.build registry + ':$BRANCH_NAME-build-$BUILD_NUMBER-arm64v8', '-f arm64v8.Dockerfile'
+                    dockerImageARM32 = docker.build registry + ':$BRANCH_NAME-build-$BUILD_NUMBER-arm32v7', '-f arm32v7.Dockerfile .'
+                    dockerImageARM64 = docker.build registry + ':$BRANCH_NAME-build-$BUILD_NUMBER-arm64v8', '-f arm64v8.Dockerfile .'
                 }
             }
         }

--- a/arm32v7.Dockerfile
+++ b/arm32v7.Dockerfile
@@ -1,0 +1,6 @@
+# teambitflow/bitflow4j:arm-latest
+FROM arm32v7/openjdk:11-jre-slim
+WORKDIR /
+ADD target/bitflow4j-*-jar-with-dependencies.jar bitflow4j.jar
+ENTRYPOINT ["java", "-jar", "bitflow4j.jar"]
+

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -1,0 +1,6 @@
+# teambitflow/bitflow4j:arm-latest
+FROM arm64v8/openjdk:11-jre-slim
+WORKDIR /
+ADD target/bitflow4j-*-jar-with-dependencies.jar bitflow4j.jar
+ENTRYPOINT ["java", "-jar", "bitflow4j.jar"]
+


### PR DESCRIPTION
This also modifies the Jenkinsfile to build Docker images for all architectures (amd64, arm32v, arm64v8) and create a docker manifest on the :latest tag.

That way - when pulling teambitflow/bitflow4j:latest - the correct architecture of the image is automatically chosen.

Furthermore, Jenkins will create :latest-amd64, :latest-arm32v7 and :latest-arm64v8 as well as :build-... tags for the respective architectures.